### PR TITLE
Parameterize DB engine_version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ resource "aws_db_instance" "rds" {
   copy_tags_to_snapshot       = true
   db_subnet_group_name        = "${aws_db_subnet_group.rds.name}"
   engine                      = "postgres"
-  engine_version              = "10.1"
+  engine_version              = "${var.engine_version}"
   final_snapshot_identifier   = "${var.name}-final"
   identifier                  = "${var.name}"
   instance_class              = "${var.instance_class}"

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "database_name" {
   type        = "string"
 }
 
+variable "engine_version" {
+	default     = "10.1"
+  description = "The version of PostgreSQL used when the DB instance is created."
+  type        = "string"
+}
+
 variable "instance_class" {
   description = "The instance type of the RDS instance."
   type        = "string"


### PR DESCRIPTION
This PR allows specification of a specific PostgreSQL version.  Even though `auto_minor_version_upgrade` is set to `true`, there may be times where it is desirable to upgrade an instance for testing before AWS forces the upgrade.